### PR TITLE
Detect non-interactive pre-commit hook calls by IDE

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,6 +5,10 @@ branch="$(git rev-parse --abbrev-ref HEAD)"
 root=$( git diff --pretty="" --name-only --staged -- packages/ | wc -l )
 
 if [[ "$branch" != "changeset-release/trunk" ]]; then
+    if [ ! -t 1 ]; then
+        export TALISMAN_INTERACTIVE="false"
+    fi
+
     ./scripts/copyright_check.sh && ./scripts/branch_warning.sh && $TALISMAN_HOME/talisman_hook_script pre-commit || exit 1
     if [[ "$root" -gt "0" ]]; then
         echo 'Detecting modified files in packages directory...'

--- a/scripts/branch_warning.sh
+++ b/scripts/branch_warning.sh
@@ -7,7 +7,14 @@
 branch="$(git rev-parse --abbrev-ref HEAD)"
 
 if [[ "$branch" != "trunk" ]]; then
-    read -p "Are you sure you want to use a branch that isn't trunk? (y/n): " -n 1 -r < /dev/tty
+    if [ -t 1 ]; then
+        # We're running interactive
+        read -p "Are you sure you want to use a branch that isn't trunk? (y/n): " -n 1 -r < /dev/tty
+    else
+        # We're running non-interactive (possibly called by IDE)
+        echo "This is not the trunk branch and we assume that's intended."
+        REPLY="Y"
+    fi
     echo
     if [[ $REPLY =~ ^[Yy]$ ]]; then
         echo "Okie dokie. Be Careful out there :)"


### PR DESCRIPTION
## Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/trunk/CONTRIBUTING.md
-->

Write a brief but concise description of the changes you have made while also making sure to **link the relevant issue number to this PR** _( e.g. fixes #ISSUE-NUMBER - optional short description)_

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] tests are changed or added
- [ ] yarn test passes
- [ ] yarn lint has been run
- [ ] git pre-commit hook is successfully executed.
      (**Please refrain from using `--no-verify`**)
- [ ] yarn changeset was run and relevant packages have been updated as a major/minor/patch bump with descriptions
      (**Determine version update using [Semantic Versioning](https://semver.org/)**)
- [ ] relevant documentation is changed or added

## Notes

Additional information relevant to the changes

© 2021 Thoughtworks, Inc.
